### PR TITLE
Use 30mb buffer to handle very large inputs

### DIFF
--- a/haklistgen.go
+++ b/haklistgen.go
@@ -13,6 +13,8 @@ import (
 func main() {
 	list := make(map[string]struct{}) // store the output lines to check for dupes
 	s := bufio.NewScanner(os.Stdin)
+	buf := make([]byte, 0, 64*1024)
+	s.Buffer(buf, 30*1024*1024) // 30mb buffer
 	r := regexp.MustCompile(`[a-zA-Z0-9\.\-\_\/]*`)
 	for s.Scan() {
 		process(s.Text(), list, r)


### PR DESCRIPTION
This PR adds a 30mb buffer to handle large inputs. Fixes the following error I would hit with very large JavaScript files.

```
cat "huge.js" | haklistgen
---
bufio.scanner token too long
```